### PR TITLE
PR89: [feature] New config parameters to require assertions and responses to be signed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# IDEs
+.vscode/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,4 +29,5 @@ Contributors
 - `BaconAndEggs <https://github.com/BaconAndEggs>`_
 - `Ryan Mahaffey <https://github.com/mahaffey>`_
 - `ayr-ton <https://github.com/ayr-ton>`_
-_ `kevPo <https://github.com/kevPo>`_
+- `kevPo <https://github.com/kevPo>`_
+- `chriskj <https://github.com/chriskj>`_

--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,8 @@ How to use?
             'USE_JWT': False, # Set this to True if you are running a Single Page Application (SPA) with Django Rest Framework (DRF), and are using JWT authentication to authorize client users
             'FRONTEND_URL': 'https://myfrontendclient.com', # Redirect URL for the client if you are using JWT auth with DRF. See explanation below
             'LOGIN_CASE_SENSITIVE': True, # whether of not to get the user in case_sentive mode
+            'WANT_ASSERTIONS_SIGNED': True, # Require each assertion to be signed
+            'WANT_RESPONSE_SIGNED': False, # Require response to be signed
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience
@@ -218,6 +220,10 @@ Default value if not specified is 'urn:oasis:names:tc:SAML:2.0:nameid-format:tra
 **FRONTEND_URL** If USE_JWT is True, you should set the URL of where your frontend is located (will default to DEFAULT_NEXT_URL if you fail to do so). Once the client is authenticated through the SAML/SSO, your client is redirected to the FRONTEND_URL with the user id (uid) and JWT token (token) as query parameters.
 Example: 'https://myfrontendclient.com/?uid=<user id>&token=<jwt token>'
 With these params your client can now authenticate will server resources.
+
+**WANT_ASSERTIONS_SIGNED** Set this to the boolean False if your provider doesn't sign each assertion.
+
+**WANT_RESPONSE_SIGNED** Set this to the boolean True if you require your provider to sign the response.
 
 Customize
 =========

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -121,6 +121,12 @@ def _get_saml_client(domain):
     if 'NAME_ID_FORMAT' in settings.SAML2_AUTH:
         saml_settings['service']['sp']['name_id_format'] = settings.SAML2_AUTH['NAME_ID_FORMAT']
 
+    if 'WANT_ASSERTIONS_SIGNED' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['want_assertions_signed'] = settings.SAML2_AUTH['WANT_ASSERTIONS_SIGNED']
+
+    if 'WANT_RESPONSE_SIGNED' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['want_response_signed'] = settings.SAML2_AUTH['WANT_RESPONSE_SIGNED']
+
     spConfig = Saml2Config()
     spConfig.load(saml_settings)
     spConfig.allow_unknown_attributes = True


### PR DESCRIPTION
PR: https://github.com/fangli/django-saml2-auth/pull/98